### PR TITLE
Allow empty content

### DIFF
--- a/src/Jade/Jade.php
+++ b/src/Jade/Jade.php
@@ -107,13 +107,8 @@ class Jade {
             ob_end_clean();
             throw $e;
         }
-        $content = ob_get_contents();
-        ob_end_clean();
-        if(empty($content))
-        {
-            throw new \Exception("Empty content at:" . $file);
-        }
-        return $content;
+        
+        return ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
> Empty content exception. One of my templates has a conditional for displaying comments based on PHP_SAPI and other factors. Basically, when my template outputted nothing Jade would throw an exception. I had to output a comment instead. Maybe you shouldn't limit the empty output?
