### PR TITLE
Pretty output printing

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -705,7 +705,7 @@ class Compiler
      */protected function createPhpBlock($code, $statements = null)
     {
         if ($statements == null) {
-            return '<?php ' . $code . '' . $this->closingTag;
+            return '<?php ' . $code . ' ' . $this->closingTag;
         }
 
         $code_format= array_pop($statements);

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -108,6 +108,11 @@ class Compiler
     protected $phpCloseBlock= array('endswitch','endif','endwhile','endfor','endforeach');
 
     /**
+     * @var string
+     */
+    protected $closingTag;
+
+    /**
      * @param bool  $prettyprint
      * @param array $filters
      */
@@ -117,6 +122,7 @@ class Compiler
         $this->phpSingleLine = $phpSingleLine;
         $this->allowMixinOverride = $allowMixinOverride;
         $this->filters = $filters;
+        $this->closingTag = '?>' . ($prettyprint === true ? ' ' : '');
     }
 
     public static function strval($val)
@@ -137,7 +143,7 @@ class Compiler
 
         // Separate in several lines to get a useable line number in case of an error occurs
         if($this->phpSingleLine) {
-            $code = str_replace(array('<?php', '?>'), array("<?php\n", "\n?>"), $code);
+            $code = str_replace(array('<?php', '?>'), array("<?php\n", "\n{$this->closingTag}"), $code);
         }
         // Remove the $ wich are not needed
         return $code;
@@ -699,7 +705,7 @@ class Compiler
      */protected function createPhpBlock($code, $statements = null)
     {
         if ($statements == null) {
-            return '<?php ' . $code . ' ?>';
+            return '<?php ' . $code . " {$this->closingTag}";
         }
 
         $code_format= array_pop($statements);
@@ -708,7 +714,7 @@ class Compiler
         if (count($statements) == 0) {
             $php_string = call_user_func_array('sprintf', $code_format);
 
-            return '<?php ' . $php_string . ' ?>';
+            return '<?php ' . $php_string . " {$this->closingTag}";
         }
 
         $stmt_string= '';
@@ -721,7 +727,7 @@ class Compiler
 
         $php_str = '<?php ';
         $php_str .= $stmt_string;
-        $php_str .= $this->newline() . $this->indent() . ' ?>';
+        $php_str .= $this->newline() . $this->indent() . " {$this->closingTag}";
 
         return $php_str;
     }

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -143,7 +143,7 @@ class Compiler
 
         // Separate in several lines to get a useable line number in case of an error occurs
         if($this->phpSingleLine) {
-            $code = str_replace(array('<?php', '?>'), array("<?php\n", "\n{$this->closingTag}"), $code);
+            $code = str_replace(array('<?php', '?>'), array("<?php\n", "\n" . $this->closingTag), $code);
         }
         // Remove the $ wich are not needed
         return $code;
@@ -705,7 +705,7 @@ class Compiler
      */protected function createPhpBlock($code, $statements = null)
     {
         if ($statements == null) {
-            return '<?php ' . $code . " {$this->closingTag}";
+            return '<?php ' . $code . '' . $this->closingTag;
         }
 
         $code_format= array_pop($statements);
@@ -714,7 +714,7 @@ class Compiler
         if (count($statements) == 0) {
             $php_string = call_user_func_array('sprintf', $code_format);
 
-            return '<?php ' . $php_string . " {$this->closingTag}";
+            return '<?php ' . $php_string . ' ' . $this->closingTag;
         }
 
         $stmt_string= '';
@@ -727,7 +727,7 @@ class Compiler
 
         $php_str = '<?php ';
         $php_str .= $stmt_string;
-        $php_str .= $this->newline() . $this->indent() . " {$this->closingTag}";
+        $php_str .= $this->newline() . $this->indent() . ' ' . $this->closingTag;
 
         return $php_str;
     }

--- a/src/Jade/Filter/Php.php
+++ b/src/Jade/Filter/Php.php
@@ -31,6 +31,6 @@ class Php implements FilterInterface {
                 $data .= $n->value . "\n";
             }
         }
-        return $data ? '<?php ' . $data . ' ?>' : $data;
+        return $data ? '<?php ' . $data . ' ?> ' : $data;
     }
 }


### PR DESCRIPTION
> Pretty printing. The cached templates are pretty printed, but output isn't "prettified." I discovered some time ago a trick that allows prettily format PHP template output. All you need to do is for every <?php ... ?> code is to put one space character after closing PHP preprocessor tag. PHP closing tags "absorb" one newline character after ?>, so the solution is simply insert one space after ?> :)
