### PR TITLE
Generate PHP source code for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 # Composer
 /vendor
 /composer.lock
-
-# Tests
-/tests/*.compiled.php

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Composer
 /vendor
 /composer.lock
+
+# Tests
+/tests/*.compiled.php

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 *.jade.html
 *.jade.php
+*.compiled.php

--- a/tests/test.php
+++ b/tests/test.php
@@ -39,6 +39,11 @@ function show_php($file) {
     return $jade->render($file);
 }
 
+function compile_php($file) {
+    $jade = new Jade\Jade();
+    return $jade->compile(file_get_contents($file . '.jade'));
+}
+
 mb_internal_encoding('utf-8');
 error_reporting(E_ALL);
 setup_autoload();
@@ -69,10 +74,12 @@ foreach($nav_list as $type => $arr) {
         }
 
         if($new !== null) {
-            file_put_contents($e['name'] . '.jade.php', $new);
             $code = `php -d error_reporting="E_ALL & ~E_NOTICE" {$e['name']}.jade.php`;
+            
+            file_put_contents($e['name'] . '.jade.php', $new);
             file_put_contents($e['name'] . '.jade.html', $code);
-
+            file_put_contents($e['name'] . '.compiled.php', compile_php($e['name']));
+            
             // automatically compare $code and $html here
             $from = array("\n", "\r", "\t", " ", '"', "<!DOCTYPEhtml>");
             $to = array('', '', '', '', "'", '');

--- a/tests/test.php
+++ b/tests/test.php
@@ -78,7 +78,10 @@ foreach($nav_list as $type => $arr) {
             
             file_put_contents($e['name'] . '.jade.php', $new);
             file_put_contents($e['name'] . '.jade.html', $code);
-            file_put_contents($e['name'] . '.compiled.php', compile_php($e['name']));
+            
+            if (!is_file($e['name'] . '.compiled.php')) {
+                file_put_contents($e['name'] . '.compiled.php', compile_php($e['name']));
+            }
             
             // automatically compare $code and $html here
             $from = array("\n", "\r", "\t", " ", '"', "<!DOCTYPEhtml>");


### PR DESCRIPTION
Hey Kyle. I think it would be much easier to test the result if tester would also generate compiled PHP files (like cached ones). This PR adds into process of testing compiled PHP templates.

What do you think?
