### PR TITLE
Merge tag space

### DIFF
--- a/src/Jade/Compiler/AttributesCompiler.php
+++ b/src/Jade/Compiler/AttributesCompiler.php
@@ -175,6 +175,6 @@ abstract class AttributesCompiler extends CompilerFacade
 
         $items .= $this->getClassesCode($classes, $classesCheck);
 
-        $this->buffer(' ' . trim($items), false);
+        $this->buffer($items, false);
     }
 }

--- a/tests/lib/bootstrap.php
+++ b/tests/lib/bootstrap.php
@@ -95,6 +95,7 @@ function orderWords($words) {
 }
 
 function get_test_result($name, $verbose = false, $moreVerbose = false) {
+    $mergeSpace = IGNORE_INDENT && strpos($name, 'indent.') === false;
     $path = TEMPLATES_DIRECTORY . DIRECTORY_SEPARATOR . $name;
     $expectedHtml = @file_get_contents($path . '.html');
     if($expectedHtml === false) {
@@ -126,14 +127,16 @@ function get_test_result($name, $verbose = false, $moreVerbose = false) {
 
     $from = array("'", "\r", "<!DOCTYPEhtml>");
     $to = array('"', '', '');
-    if (IGNORE_INDENT && strpos($name, 'indent.') === false) {
+    if ($mergeSpace) {
         array_push($from, "\n", "\t", " ");
         array_push($to, '', '', '');
     }
     $expectedHtml = preg_replace_callback('`class\s*=\s*(["\'])([^"\']+)\\1`', 'orderWords', $expectedHtml);
     $actualHtml = preg_replace_callback('`class\s*=\s*(["\'])([^"\']+)\\1`', 'orderWords', $actualHtml);
-    $expectedHtml = preg_replace('`(?<=[\'"])\s(?=>)|(?<=[a-zA-Z0-9:])\s(?=(>|\s[a-zA-Z0-9:]))`', '', $expectedHtml);
-    $actualHtml = preg_replace('`(?<=[\'"])\s(?=>)|(?<=[a-zA-Z0-9:])\s(?=(>|\s[a-zA-Z0-9:]))`', '', $actualHtml);
+    if ($mergeSpace) {
+        $expectedHtml = preg_replace('`(?<=[\'"])\s(?=>)|(?<=[a-zA-Z0-9:])\s(?=(>|\s[a-zA-Z0-9:]))`', '', $expectedHtml);
+        $actualHtml = preg_replace('`(?<=[\'"])\s(?=>)|(?<=[a-zA-Z0-9:])\s(?=(>|\s[a-zA-Z0-9:]))`', '', $actualHtml);
+    }
     $minifiedExpectedHtml = str_replace($from, $to, trim($expectedHtml));
     $minifiedActualHtml = str_replace($from, $to, trim($actualHtml));
     $result = array($name, $minifiedExpectedHtml, $minifiedActualHtml);

--- a/tests/templates/indent.merge-tag-space.html
+++ b/tests/templates/indent.merge-tag-space.html
@@ -1,0 +1,8 @@
+<tag id="test-id">ID</tag>
+<tag foo="bar" baz="toto">Attributes</tag>
+<tag class="test-class">Class</tag>
+<tag id="test-id" class="test-class">ID + class</tag>
+<tag id="test-id" foo="bar" baz="toto">ID + attributes</tag>
+<tag foo="bar" baz="toto" class="test-class">Attributes + class</tag>
+<tag id="test-id" foo="bar" baz="toto" class="test-class">ID + attributes + class</tag>
+<tag id="test-id" foo="bar" baz="toto" class="test-class">Class + ID + attributes</tag>

--- a/tests/templates/indent.merge-tag-space.jade
+++ b/tests/templates/indent.merge-tag-space.jade
@@ -1,0 +1,23 @@
+tag#test-id ID
+tag(
+    foo="bar",
+    baz="toto"
+) Attributes
+tag.test-class Class
+tag#test-id.test-class ID + class
+tag#test-id(
+    foo="bar",
+    baz="toto"
+) ID + attributes
+tag.test-class(
+    foo="bar",
+    baz="toto"
+) Attributes + class
+tag#test-id.test-class(
+    foo="bar",
+    baz="toto"
+) ID + attributes + class
+tag.test-class#test-id(
+    foo="bar",
+    baz="toto"
+) Class + ID + attributes


### PR DESCRIPTION
`Pug::render()` sometimes adds extra white space after the tag name. For example given this Pug code:

``` jade
tag.test-class Class
```

`Pug::render()` returns this HTML code:

``` html
<tag  class='test-class'>Class</tag>
```

(note the 2 spaces after `<tag`)

This PR fixes this by removing the space which is forced in `AttributesCompiler::compileAttributes()`. `trim()` is also removed as we now need to preserve the leading space, which seems to be already done for both literal output and PHP-generated output.

A test has been added and the relevant bootstrapping code has been slightly altered to allow this failure to be detected.
